### PR TITLE
Add add_header

### DIFF
--- a/files/nginx.conf.tmpl
+++ b/files/nginx.conf.tmpl
@@ -69,8 +69,11 @@ http {
             proxy_pass_header Access-Control-Allow-Origin;
             proxy_pass_header Access-Control-Allow-Methods;
             proxy_hide_header Access-Control-Allow-Headers;
-            add_header Access-Control-Allow-Headers 'X-Requested-With, Content-Type';
+            add_header Access-Control-Allow-Origin $http_origin;
+            add_header Access-Control-Allow-Methods 'OPTIONS, HEAD, GET, POST, PUT, DELETE';
+            add_header Access-Control-Allow-Headers 'Authorization, X-Requested-With, Content-Type';
             add_header Access-Control-Allow-Credentials true;
+
 
             # Authorize access
             auth_basic           "Authentication";

--- a/files/nginx.conf.tmpl
+++ b/files/nginx.conf.tmpl
@@ -71,7 +71,7 @@ http {
             proxy_hide_header Access-Control-Allow-Headers;
             add_header Access-Control-Allow-Origin $http_origin;
             add_header Access-Control-Allow-Methods 'OPTIONS, HEAD, GET, POST, PUT, DELETE';
-            add_header Access-Control-Allow-Headers 'Authorization, X-Requested-With, Content-Type';
+            add_header Access-Control-Allow-Headers 'Authorization, X-Requested-With, Content-Type, Content-Length';
             add_header Access-Control-Allow-Credentials true;
 
 


### PR DESCRIPTION
## WHY

ref. https://github.com/tutumcloud/elasticsearch/blob/master/nginx_default

Fix `No 'Access-Control-Allow-Origin' header is present on the requested resource.`

## WHAT

- setup to Access-Control-Allow-Origin, Access-Control-Allow-Methods, Access-Control-Allow-Headers
