### PR TITLE
Add :8090/nginx_status endpoint

### DIFF
--- a/files/nginx.conf.tmpl
+++ b/files/nginx.conf.tmpl
@@ -86,4 +86,13 @@ http {
             proxy_pass {{ var "BACKEND_URL" }};
         }
     }
+
+    server {
+      listen 8090;
+
+      location /nginx_status {
+        stub_status on;
+        access_log off;
+      }
+    }
 }


### PR DESCRIPTION
## WHY

We want to monior Nginx in detail.

## WHAT

Add `:8090/nginx_status` endpoint to retrieve Nginx metrics.

- [Datadog-NGINX Integration](https://docs.datadoghq.com/ja/integrations/nginx/)